### PR TITLE
Update step

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,10 +1,8 @@
-#!/bin/bash
-set -ex
+#!/usr/bin/env bash
+#
+# Uploads an ipa to Diawi
+set -e
 
-set -o pipefail
-
-npm install -g diawi
-
-URL=`diawi upload ${api_token} ${filename}`
-
-envman add --key DIAWI_UPLOAD_URL --value $URL
+which diawi >/dev/null 2>&1 || npm install -g diawi
+diawi_url=$(diawi upload "${api_token}" "${filename}")
+envman add --key DIAWI_UPLOAD_URL --value "${diawi_url}"


### PR DESCRIPTION
Hi @deanWombourne,

Thanks for the new Step!
I created a little update to follow shell scripting guide lines.

- Updated Shebang for portability (`bash` doesn't live in `/bin` on all systems)
- A top-level comment with a description of its contents
- Install `npm` only if not previously installed
- There is no need for `set -o pipefail` if not using any pipes
- In case of command substitution `$(...)` is preferred over backticks
- Double quote variables to avoid world splitting