### PR TITLE
fix: use eval to execute function

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -20,6 +20,6 @@ cmd="${cmd} ${api_token} ${filename}"
 echo "Running command '${cmd}'"
 
 # Run the command
-diawi_url=$(cmd)
+diawi_url=eval $cmd
 echo Diawi Upload URL is $diawi_url
 envman add --key DIAWI_UPLOAD_URL --value "${diawi_url}"


### PR DESCRIPTION
Previous implementation was causing `cmd: command not found` error.

This opts for `eval`, and it seems to be working locally.