### PR TITLE
fix: use backtick syntax to execute command

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -20,6 +20,6 @@ cmd="${cmd} ${api_token} ${filename}"
 echo "Running command '${cmd}'"
 
 # Run the command
-diawi_url=eval $cmd
+diawi_url=`$cmd`
 echo Diawi Upload URL is $diawi_url
 envman add --key DIAWI_UPLOAD_URL --value "${diawi_url}"


### PR DESCRIPTION
`eval $cmd` was causing a password protected upload and a public upload.

Opt for backtick command.
```
`$cmd`
```